### PR TITLE
fix: include index.d.ts in exports for type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./dist/bundle.esm.js",
-      "require": "./dist/bundle.cjs.js"
+      "require": "./dist/bundle.cjs.js",
+      "types": "./dist/index.d.ts"
     },
     "./assets/*": "./dist/assets/*"
   },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/acecfc13-4b49-42c3-8614-4228c883acbb)
Due to the current type error shown in the image above, it's difficult to use the package with TypeScript.
To fix this, I added the necessary types field to package.json.
After testing it locally as a package, I created this MR.